### PR TITLE
Do not use an enumerate type to identify the teams, but strings instead.

### DIFF
--- a/orwell/messages/test/test_messages.py
+++ b/orwell/messages/test/test_messages.py
@@ -28,7 +28,7 @@ def test_game_state():
     message = pb_server_game.GameState()
     playing = True
     seconds = 42
-    winner = pb_server_game.RED
+    winner = "team_banana"
     message.playing = playing
     message.seconds = seconds
     message.winner = winner
@@ -43,7 +43,7 @@ def test_game_state():
 def test_welcome(use_optional):
     message = pb_server_game.Welcome()
     robot = "TANK_1"
-    team = pb_server_game.BLU
+    team = "team_blue"
     robot_id = "84"
     playing = True
     seconds = 123456
@@ -58,10 +58,12 @@ def test_welcome(use_optional):
     if (use_optional):
         message.game_state.playing = playing
         message.game_state.seconds = seconds
-        message.game_state.blu.score = blu_score
-        message.game_state.blu.num_players = blu_num
-        message.game_state.red.score = red_score
-        message.game_state.red.num_players = red_num
+        team_blu = message.game_state.teams.add()
+        team_blu.score = blu_score
+        team_blu.num_players = blu_num
+        team_red = message.game_state.teams.add()
+        team_red.score = red_score
+        team_red.num_players = red_num
     message.id = robot_id
     message.video_address = video_address
     message.video_port = video_port
@@ -73,17 +75,14 @@ def test_welcome(use_optional):
     if (use_optional):
         assert(message2.game_state.playing == playing)
         assert(message2.game_state.seconds == seconds)
-        assert(message2.game_state.blu.score == blu_score)
-        assert(message2.game_state.blu.num_players == blu_num)
-        assert(message2.game_state.red.score == red_score)
-        assert(message2.game_state.red.num_players == red_num)
+        assert(message2.game_state.teams[0].score == blu_score)
+        assert(message2.game_state.teams[0].num_players == blu_num)
+        assert(message2.game_state.teams[1].score == red_score)
+        assert(message2.game_state.teams[1].num_players == red_num)
     else:
         assert(not message2.game_state.playing)
         assert(message2.game_state.seconds == 0)
-        assert(message2.game_state.blu.score == 0)
-        assert(message2.game_state.blu.num_players == 0)
-        assert(message2.game_state.red.score == 0)
-        assert(message2.game_state.red.num_players == 0)
+        assert(len(message2.game_state.teams) == 0)
     assert(message2.id == robot_id)
     assert(message.video_address == video_address)
     assert(message.video_port == video_port)
@@ -125,7 +124,7 @@ def test_stop():
 def test_registered():
     message = pb_server_game.Registered()
     robot_id = 'Toto'
-    team = pb_server_game.RED
+    team = "team_red"
     message.robot_id = robot_id
     message.team = team
     payload = message.SerializeToString()

--- a/server-game.proto
+++ b/server-game.proto
@@ -2,12 +2,6 @@ option optimize_for = LITE_RUNTIME;
 
 package orwell.messages;
 
-// supposing there are two teams
-enum EnumTeam {
-	RED = 0;
-	BLU = 1;
-}
-
 // Information about the team
 // not sent on its own
 message Team {
@@ -22,17 +16,16 @@ message GameState {
 	required bool playing = 1;
 	// number of seconds left before the game ends (useless if playing is false)
 	optional uint64 seconds = 2;
-	optional Team blu = 3;
-	optional Team red = 4;
+	repeated Team teams = 3;
 	// only set when playing is false and seconds is 0 (ie when the game is finished)
-	optional EnumTeam winner = 5;
+	optional string winner = 4;
 }
 
 // Tell a player how (s)he is and where (s)he plays
 // reply to: Hello
 message Welcome {
 	required string robot = 1;
-	required EnumTeam team = 2;
+	required string team = 2;
 	optional GameState game_state = 3;
 	required string id = 4;
 	required string video_address = 5;
@@ -68,6 +61,6 @@ message Stop {
 message Registered {
 	// this is the definitive robot ID to be used for communications
 	required string robot_id = 1;
-	optional EnumTeam team = 2;
+	optional string team = 2;
 }
 


### PR DESCRIPTION
Allow more than two teams.