### PR TITLE
Force Protocol Buffers to version 2 to avoid surprises

### DIFF
--- a/common.proto
+++ b/common.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 option optimize_for = LITE_RUNTIME;
 
 package orwell.messages;

--- a/controller.proto
+++ b/controller.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 option optimize_for = LITE_RUNTIME;
 
 import "common.proto";

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-protobuf==2.5.0
+pkg-resources==0.0.0
+protobuf==3.8.0
+six==1.12.0

--- a/robot.proto
+++ b/robot.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 option optimize_for = LITE_RUNTIME;
 
 import "common.proto";

--- a/server-game.proto
+++ b/server-game.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 option optimize_for = LITE_RUNTIME;
 
 import public "common.proto";

--- a/server-web.proto
+++ b/server-web.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 option optimize_for = LITE_RUNTIME;
 
 package orwell.messages;


### PR DESCRIPTION
Protobuf 3 is now much more common which can still work with version 2.